### PR TITLE
docs: refresh community hybrid rag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,38 @@
-# Hybrid RAG Using BM25: Better Option for AI Governance
+# Hybrid BM25 + Vector RAG (Community Edition)
 
-Welcome to the **Hybrid RAG Guide**: a dual-memory (LT + HOT) Vector + BM25 approach to Retrieval-Augmented Generation that delivers answers that are **transparent, deterministic, and governance-ready** by design. The repo houses two fully working paths:
+This repository contains a laptop-friendly hybrid Retrieval-Augmented Generation (RAG) stack built on **OpenSearch BM25**, optional **vector search**, and a local **llama.cpp** model. The Python code under `community_version/` is the authoritative implementation; documentation now mirrors that code.
 
-* **Community / Open-Source Version**: a self-contained demo you can run on a laptop or in a pure open-source deployment.
-* **Enterprise Version**: a production-grade variant that layers in ingest pipelines, NetApp FlexCache, SnapMirror, and other operational muscle.
+The system favors explainability and auditability:
 
-![Document RAG with Reinforcement Learning](./images/reinforcement_learning.png)
+* **Lexical-first retrieval.** Queries start with entity-aware BM25 searches against paragraph-level chunks in both long-term and HOT stores.
+* **Optional dense signals.** Question embeddings can add vector matches, but lexical evidence always remains in the result set.
+* **Transparent scoring.** An external BM25 re-ranker (via [`bm25s`](https://github.com/xhluca/bm25s)) is enabled by default so the ranked list is reproducible and inspectable.
 
-By storing knowledge as **documents with enriched metadata** (named entities and provenance tags) instead of opaque vectors alone, the agent gains traceability, reduces hallucinations, and meets demanding audit requirements.
+## Repository layout
 
-### Project Purpose
+* `community_version/` – runnable hybrid RAG demo (ingestion, query, HOT reinforcement utilities).
+* `Document_Search_for_Better_AI_Governance.md` – background on why lexical-first retrieval improves governance.
+* `OSS_Community_Version.md` / `Enterprise_Version.md` – narrative guides for broader deployments.
 
-This project was developed to address limitations of traditional vector-centric RAG and to make retrieval **explainable** and **auditable**.
+If you want to run the stack, start with `community_version/README.md` for setup, configuration, and commands.
 
-* **Performance & latency**: The LT/HOT split exists primarily for **governance boundaries**, **retention variations control**, and **policy asymmetry**; retrieval remains lexical-first and observable.
-* **Transparency and Explainability**: Vector embeddings are opaque. Document-based RAG stores explicit entity metadata (`explicit_terms`, `explicit_terms_text`) and uses fielded, auditable BM25 queries so you can show *why* a document matched.
-
-Key objectives include:
-
-* Provide a reference architecture for **Document-based RAG** with explicit **HOT (unstable)** and **Long-Term (LT)** tiers.
-* Make promotion from **HOT → LT** a **controlled event** that happens only when (1) there is **enough positive reinforcement** of the data **or** (2) a **trusted human-in-the-loop** has verified it.
-* Show upgrade paths-from a minimal Python demo to an enterprise pipeline with NetApp enterprise storage.
-
-## Benefits Over Vector-Based RAG
-
-Adopting Document-based RAG addresses several key limitations of traditional RAG agents:
-
-* **Multi-Step Reasoning**: OpenSearch indexing with entity enrichment supports complex, entity-aware queries across related documents.
-* **Bias Mitigation**: Explicit metadata and annotations expose skew and make it easier to correct.
-* **Improved Compliance and Governance**: Provenance fields and auditable clauses enable traceable, regulator-friendly retrieval.
-* **Risk Management**: Deterministic lexical logic and highlights reduce hallucinations and make review straightforward.
-
-### Community vs Enterprise: What Changes?
-
-| Capability                 | Community Edition                             | Enterprise Edition                                                          |
-| -------------------------- | --------------------------------------------- | --------------------------------------------------------------------------- |
-| **HOT backing store**      | `tmpfs` / RAM-disk on the dev box             | **NetApp FlexCache** for locality; durability via **SnapMirror** replicas   |
-| **Governance hooks**       | Basic provenance tags                         | Promotion events logged, schema-versioned, and instantly traceable          |
-| **Latency posture**        | Latency is secondary to governance boundaries | Latency tuned per SLA, but the split is for **governance/policy asymmetry** |
-
-> **TL;DR:** start with the community guide for laptops and commodity hardware; switch to the enterprise path when you need multi-site, 24×7, and **governance** at scale. The split exists for **control and auditability**, not because latency forces it.
-
-## Where To Dive Deeper
-
-| Document                                     | What it covers                                                                                        |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Document Search for Better AI Governance** | Vision & governance rationale for Document RAG [link](./Document_Search_for_Better_AI_Governance.md)  |
-| **Community Version Guide**                  | Step-by-step setup for the open-source flavour [link](./OSS_Community_Version.md)                     |
-| **Community README**                         | Hands-on commands & scripts [link](./community_version/README.md)                                     |
-| **Enterprise Version Guide**                 | Deep dive on ingest pipelines, FlexCache, SnapMirror [link](./Enterprise_Version.md)                  |
-| **Enterprise README**                        | Production deployment notes [link](./enterprise_version/README.md)                                    |
-
-## Quick Start
+## Quick start
 
 ```bash
-# 1. Clone the repo
-$ git clone https://github.com/davidvonthenen/document-rag-guide.git
+cd community_version
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python -m spacy download en_core_web_sm
 
-# 2. Pick your path
-$ cd document-rag-guide/community_version   # laptop demo
-# or
-$ cd document-rag-guide/enterprise_version  # prod-ready setup
+# Run the local spaCy NER API required by the pipeline
+python ner_service.py
 
-# 3. Follow the README in that folder
+# Ingest the BBC dataset into OpenSearch (long-term BM25 + vector chunks)
+python ingest.py --data-dir bbc
+
+# Ask questions using hybrid BM25 + vector retrieval
+python query.py --question "What did Google purchase Windsurf for?" --observability
 ```
 
-Questions? Open an issue or start a discussion and contributions are welcome!
+See the community README for environment variable overrides (OpenSearch hosts/indices, llama.cpp model path, ranking knobs) and HOT memory workflows.
+

--- a/community_version/README.md
+++ b/community_version/README.md
@@ -1,195 +1,105 @@
-# Pure Open Source Community Implementation for Document RAG with Reinforcement Learning
+# Community Hybrid RAG
 
-This README.md provides an **open-source/community-oriented reference implementation** for a  lexical-first Retrieval-Augmented Generation (RAG) system, which supports a HOT data and reinforcement learning to consume new facts. This is modeled after a specific example, so your implementation might differ materially from the specifics here; however, the high-level concepts are the same.
+The `community_version` folder contains a self-contained hybrid RAG stack that combines:
+
+* **Paragraph-level BM25 search** over long-term and HOT OpenSearch indices with NER-derived entity fields.
+* **Optional k-NN vector search** over chunk embeddings.
+* **Local llama.cpp inference** with a constrained prompt so answers cite only retrieved context.
+
+The Python code is the source of truth for behavior; this README mirrors the current implementation.
+
+## Components
+
+* `ingest.py` – walks the BBC news dataset, extracts named entities, and indexes both full documents and paragraph chunks into BM25 plus a vector chunk index.
+* `query.py` – CLI that runs NER on the question, queries LONG + HOT + vector stores in parallel, optionally re-ranks with the local `bm25s` pass, and feeds the merged context to the LLM.
+* `example/reinforcement_learning.py` – populates the HOT index with demo facts and exercises the hybrid query path.
+* `expire_hot_data.py` / `manual_promote.py` – helpers for expiring or promoting HOT facts when experimenting with governance flows.
+* `ner_service.py` – lightweight Flask HTTP service that exposes spaCy NER (`/health`, `/ner`). All ingestion and query paths depend on it.
 
 ## Prerequisites
 
-- A Linux or Mac-based development machine with sufficient memory to run two OpenSearch instances and an LLM (≈8B parameters).
-  - *Windows users:* use a Linux VM or cloud instance if possible.
-- **Python 3.10+** installed (with [venv](https://docs.python.org/3/library/venv.html) or [miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main) for isolation).
-- **Docker** installed (for running OpenSearch, etc.).
-- Basic familiarity with shell and Docker commands.
+* Python 3.10+
+* Two reachable OpenSearch nodes (or two indices on one node) for LONG and HOT. Defaults: `127.0.0.1:9201` (LONG) and `127.0.0.1:9202` (HOT).
+* Local llama.cpp-compatible model file (path configurable via `LLAMA_MODEL_PATH`).
+* BBC dataset extracted under `community_version/bbc/<category>/*.txt` (default `--data-dir bbc`).
+* spaCy model `en_core_web_sm` installed for NER.
 
-**Docker images to pre-pull:**
-
-- `opensearchproject/opensearch:3.2.0` (used for both long-term and HOT instances)
-
-### LLM to pre-download:
-
-For example, you can use the following 7-8B parameter models that run locally (CPU-friendly via [llama.cpp](https://github.com/ggerganov/llama.cpp)):
-
-- Intel's **neural-chat-7B-v3-3-GGUF** - *(tested model)* available on HuggingFace
-- OR [bartowski/Meta-Llama-3-8B-Instruct-GGUF](https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf) - an 8B instruction-tuned Llama variant.
-- OR use an API/manager like [Ollama](https://ollama.com/), e.g. `ollama pull llama3:8b` for an 8B Llama model.
-
-## Setting Up the Environment
-
-To get started, we need to set up two main components of our environment: a OpenSearch database and a local LLM for question-answering. We'll use **Docker** to run OpenSearch. You'll need to download an LLM (we'll provide some recommendations) and set up a Python environment for our code.
-
-### Demonstration Purposes
-
-For demonstration purposes, we will create 2 OpenSearch instances: one instance for Long-Term vetted data and second instance for Hot / unstable data.
-
-### Launch OpenSearch with Docker
-
-Create a private network and bring up **long-term** and **HOT** instances. We’ll expose **9201** (LT) and **9202** (HOT) on localhost and disable the security plugin for a frictionless demo.
+## Setup
 
 ```bash
-# create a docker network so that opensearch instances and dashboards can access each other
-docker network create opensearch-net
-
-# opensearch for long-term data retention
-docker run -d \
-    --name opensearch-longterm \
-    --network opensearch-net \
-    -p 9201:9200 -p 9601:9600 \
-    -e "discovery.type=single-node" \
-    -e "DISABLE_SECURITY_PLUGIN=true" \
-    -v "$HOME/opensearch-longterm/data:/usr/share/opensearch/data" \
-    -v "$HOME/opensearch-longterm/snapshots:/mnt/snapshots" \
-    opensearchproject/opensearch:3.2.0
-
-# (optional) opensearch dashboards for debugging, observability
-docker run -d \
-    --name opensearch-longterm-dashboards \
-    --network opensearch-net \
-    -p 5601:5601 \
-    -e 'OPENSEARCH_HOSTS=["http://opensearch-longterm:9200"]' \
-    -e 'DISABLE_SECURITY_DASHBOARDS_PLUGIN=true' \
-    opensearchproject/opensearch-dashboards:3.2.0
-
-# opensearch for HOT data
-docker run -d \
-    --name opensearch-shortterm \
-    --network opensearch-net \
-    -p 9202:9200 -p 9602:9600 \
-    -e "discovery.type=single-node" \
-    -e "DISABLE_SECURITY_PLUGIN=true" \
-    -v "$HOME/opensearch-shortterm/data:/usr/share/opensearch/data" \
-    -v "$HOME/opensearch-shortterm/snapshots:/mnt/snapshots" \
-    opensearchproject/opensearch:3.2.0
-
-# (optional) opensearch dashboards for debugging, observability
-docker run -d \
-    --name opensearch-shortterm-dashboards \
-    --network opensearch-net \
-    -p 5602:5601 \
-    -e 'OPENSEARCH_HOSTS=["http://opensearch-shortterm:9200"]' \
-    -e 'DISABLE_SECURITY_DASHBOARDS_PLUGIN=true' \
-    opensearchproject/opensearch-dashboards:3.2.0
-```
-
-This will download the OpenSearch image (if not already present) and start two OpenSearch servers in the background. The OpenSearch database will be empty initially. You can verify it's running by opening the OpenSearch Browser at **[http://127.0.0.1:9201](http://127.0.0.1:9201)** and **["http://127.0.0.1:9202]("http://127.0.0.1:9202)** in your browser. 
-
-> **IMPORTANT:** The password for the `Long-term Memory` and the `Short-term Memory` instance has been disable for ease of use. In production environments, remove this line `DISABLE_SECURITY_DASHBOARDS_PLUGIN=true` from the docker command for starting up the containers.
-
-### Python Environment and Dependencies
-
-With the OpenSearch instances running and the model file ready, set up a Python environment for running the provided code. You should have Python 3.10+ available. It's recommended to use a virtual environment or a Conda environment for the lab.
-
-Install the required Python libraries using pip. A convenient `requirements.txt` file has been provided for you. 
-
-```bash
+python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-```
-
-After installing spaCy, download the small English model for NER:
-
-```bash
 python -m spacy download en_core_web_sm
-```
 
-### Start the NER HTTP Service
-
-This solution uses a default Named Entity Recognition model for association `keywords` to `documents`. It's highly recommended that if your problem or domain area uses unique language set (for example, medical, legal, etc), the keyword selection will highly benefit from using a language specific NER model. 
-
-To launch the packaged NER endpoint (default `http://127.0.0.1:8000/ner`) to extract entities, run the following command on a bash terminal:
-
-```bash
+# Start the HTTP NER service used by ingest/query
 python ner_service.py
 ```
 
-## Background on the Data
+Ensure your OpenSearch instances are running and reachable according to the environment variables below before ingesting data.
 
-Our knowledge source is a collection of BBC news articles in text format, which can be found in the zip file [bbc-example.zip](./bbc-example.zip). This zip file contains a subset of 300 BBC news articles from the 2225 articles in the [BBC Full Text Document Classification](https://bit.ly/4hBKNjp) dataset. After unzipping the archive, the directory structure will look like:
-
-```
-bbc/
-├── tech/
-    ├── 001.txt
-    ├── 002.txt
-    ├── 003.txt
-    ├── 004.txt
-    ├── 005.txt
-    └── ...
-```
-
-Each file is a news article relating to technology in the world today.
-
-You may need to unzip the `bbc-example.zip` file, which you can do by running this script:
+## Data ingestion
 
 ```bash
-unzip bbc-example.zip
+python ingest.py --data-dir bbc --batch-size 32
 ```
 
-## Paragraph-Level Chunking Demo
+What happens during ingestion (per the code in `ingest.py`):
 
-The reference ingest (`community_version/ingest.py`) now writes **two** indices on every run:
+1. Connects to the LONG OpenSearch host and ensures three indices exist using the configured names:
+   * Full-document BM25: `opensearch_full_index` (default `bbc-bm25-full`).
+   * Paragraph BM25 chunks: `opensearch_long_index` (default `bbc-bm25-chunks`).
+   * Vector chunk index: `opensearch_vector_index` (default `bbc-vector-chunks`).
+2. Splits each BBC article into paragraphs, extracts entities via the running NER service, and writes:
+   * Full documents with `explicit_terms`/`explicit_terms_text` metadata to the full BM25 index.
+   * Paragraph chunks with chunk metadata (`chunk_index`, `chunk_count`, `parent_filepath`) to the BM25 chunk index.
+   * Chunk embeddings (using `thenlper/gte-small` by default) to the vector index.
+3. Refreshes all indices and logs counts of documents and chunks ingested.
 
-* `INDEX_NAME` (default `bbc`) contains the full documents with metadata for provenance.
-* `CHUNK_INDEX_NAME` (default `bbc-chunks`) stores deterministic paragraph slices. Each record carries `parent_filepath`, `chunk_index`, and `chunk_count` so you can trace the snippet back to the source file when auditors ask where a fact originated.
+The ingest script only targets the LONG cluster; HOT content is added separately via the reinforcement or promotion scripts.
 
-Query helpers in `community_version/common.py` point to the chunk index by default, so BM25 hits already map to paragraph-scale spans. Adjust `split_into_paragraphs()` if your corpus needs different chunking heuristics, or swap `LONG_INDEX_NAME`/`HOT_INDEX_NAME` env vars if you prefer document-level retrieval.
+## Querying
 
-## Example Workflows
+```bash
+python query.py --question "How much did Google purchase Windsurf for?" --observability --top-k 8
+```
 
-Here are different workflows that demonstrate how a Document RAG solution can lead to better AI Governance.
+Query flow (implemented in `common/llm.py`):
 
-### 1. Simple Query Example
+1. Run NER over the question; build an entity-aware BM25 query using `terms_set` + `multi_match` branches.
+2. Execute LONG BM25, HOT BM25, and vector k-NN searches **in parallel**.
+3. By default, re-rank the combined LONG+HOT BM25 hits locally with `bm25s`; otherwise rely on OpenSearch scores (`--observability` prints the choice).
+4. Normalize vector hits and merge them with BM25 results, reserving a configurable share for dense matches via `RANKING_ALPHA`.
+5. Build a provenance-friendly context block (store label + filepath + content) and pass it to the llama.cpp model to generate the answer.
+6. Optional `--save-results <path>` writes JSONL audit records of the run.
 
-In this scenario, we will ingest data into the long-term OpenSearch and then execute a query to see the basic mechanics of retrieving data from OpenSearch..
+If `--question` is omitted, the script uses two built-in sample questions. The CLI prints query JSON, store summaries, and kept matches when `--observability` is enabled.
 
-1. **Perform the Ingest**: Run `python ingest.py`
-   **WARNING:** This will erase any existing nodes and edges in your OpenSearch database and then reload the BBC dataset afresh. The ingest process will parse the documents, split them into paragraphs (the default chunking mode), perform NER to extract entities, and merge everything into the **long-term** OpenSearch instance and its companion chunk index. Each relationship is annotated with metadata, including its source document, ingestion timestamp, and a schema version tag for governance purposes.
+## HOT memory workflow
 
-2. **Perform a Simple Query**: Run `python query.py`
- This script poses a sample question to the system. This will retrieve facts from both the **long-term** and the **hot** OpenSearch instances. If you enable the debugging and tracing, you will see the query operation search for keywords in both OpenSearch instances. Since only the **long-term** instance has data, you will only see results from the **long-term** instance return back to the query.
+* `example/reinforcement_learning.py` prompts you to inject example facts into the HOT index, then asks a few test questions through the same query path.
+* `manual_promote.py` marks HOT facts for promotion, and `expire_hot_data.py` removes expired items to simulate cache cleanup.
 
-### 2. Reinforcement Learning
+These helpers rely on the same field schema as the LONG BM25 chunk index. Set `OPENSEARCH_HOT_*` variables if your HOT store differs from the defaults.
 
-This workflow illustrates how new facts can be introduced and evaluated in **hot** memory, and how the system utilizes a reinforcement learning (RL)-style feedback loop to determine which facts are promoted to long-term memory. We will simulate adding new information and then "teaching" the system through usage and validation. Not depicted in this example is the `CRON` job implementation, which invokes the following scripts: `expire_hot_data.py` and `python manual_promote.py` to handle promotion and expiration of facts from **hot** memory.
+## Configuration
 
-1. **Perform the Ingest**: Run `python ingest.py`
-   **WARNING:** This will erase any existing nodes and edges in your OpenSearch databases (both **long-term** and **hot**) and then reload the BBC dataset afresh. The ingest process will parse the documents, split them into paragraphs (our default chunk size), perform NER to extract entities, and merge everything into the **long-term** OpenSearch instance alongside the paragraph chunk index. Each relationship is annotated with metadata, including its source document, ingestion timestamp, and a schema version tag for governance purposes.
+All scripts load settings from `common/config.py` with `.env` support. Key overrides:
 
-2. **Enter New Facts Into HOT Memory**: Run `python example/reinforcement_learning.py`
- This example script will prompt you to introduce five new "facts" into the **hot** memory. These could be considered insights or data points not present in the original dataset. For example, facts #1 and #3 are about **OpenAI** (which are not in the BBC tech articles by default). You can choose to inject all or some of these facts; we recommend selecting **fact #1 and fact #3** for this demo. In this simplified script, the use of facts through the queries serves as a reinforcement signal.
+| Purpose | Environment variables | Defaults |
+| --- | --- | --- |
+| LONG BM25 host/index | `OPENSEARCH_LONG_HOST`, `OPENSEARCH_LONG_PORT`, `OPENSEARCH_LONG_INDEX` | `127.0.0.1`, `9201`, `bbc-bm25-chunks` |
+| HOT BM25 host/index | `OPENSEARCH_HOT_HOST`, `OPENSEARCH_HOT_PORT`, `OPENSEARCH_HOT_INDEX` | `127.0.0.1`, `9202`, `bbc-bm25-chunks` |
+| Full-document index | `OPENSEARCH_FULL_INDEX` | `bbc-bm25-full` |
+| Vector index | `OPENSEARCH_VECTOR_INDEX` | `bbc-vector-chunks` |
+| Search sizing & ranking | `SEARCH_SIZE`, `RANKING_ALPHA`, `RAG_TOP_K`, `RAG_NUM_CANDIDATES` | `10`, `0.5`, `3`, `50` |
+| LLM (llama.cpp) | `LLAMA_MODEL_PATH`, `LLAMA_CTX`, `LLAMA_N_THREADS`, `LLAMA_N_GPU_LAYERS`, `LLAMA_N_BATCH`, `LLAMA_N_UBATCH`, `LLAMA_LOW_VRAM` | see defaults in `common/config.py` |
+| NER service | `NER_URL`, `NER_TIMEOUT_SECS` | `http://127.0.0.1:8000/ner`, `5.0` |
 
-3. **Perform a Simple Query**: Run `python example/query.py`
- This script poses a sample question based on the **OpenAI** recommended to add into **hot memory** (ie, **fact #1 and fact #3**). A specific question based on these **OpenAI** facts will be asked, this will retrieve facts from both the **long-term** and the **hot** OpenSearch instances. If you enable the debugging and tracing, you will see the query operation search for keywords in both OpenSearch instances.
+The `RANKING_ALPHA` value is used both to threshold BM25 hits when OpenSearch scores are trusted and to determine how many vector results are reserved in the hybrid merge.
 
-4. **Mark One Fact Into Long-Term Memory**: Run `python manual_promote.py`
- This script allows us to flag specific **hot** facts as *validated* (worthy of long-term preservation) and others as *expired*. Following the recommendation, select the fact you added as #1 (e.g., the first OpenAI fact) to **promote**, and select fact #3 to let it *expire*.
+## Troubleshooting
 
-5. **Expire HOT Memory/Cache**: Run `python expire_hot_data.py`
- This will remove any remaining facts in the **hot** instance that have expired or were marked to expire (in our case, fact #3, which we did not promote). This step simulates the cache eviction process for facts that prove not to be useful. In a production environment, such expiration could also be handled by Kafka Connect emitting a *tombstone* event or by a scheduled job that prunes expired data. (For instance, if a fact is not promoted and its time-to-live lapses, it will simply disappear from the cache, leaving only long-term facts stored permanently.)
+* Verify the NER service is running; both ingest and query call it before constructing documents or queries.
+* Ensure LONG and HOT hosts/ports match your OpenSearch deployment; connection errors surface in the CLI output when `--observability` is enabled.
+* For Metal/low-VRAM environments, set `LLAMA_LOW_VRAM=true` and adjust `LLAMA_N_GPU_LAYERS` as needed.
 
-6. **Verify Fact Can Be Queried**: Run `python example/query.py`
- This will query both OpenSearch instances and if you have the logging/debugging enabled in the script, you will notice that the **OpenAI** fact is now retrieved from the **long-term** instance. This demonstrates that the fact was successfully carried over. In contrast, if you query for fact #3 (the one we let expire), it will not be found in either database (having been purged from **hot** and never added to **long-term**).
-
-7. **Reset Both Long-Term and HOT Instances**: Run `python helper/wipe_all_memory.py`.
- This stops and/or clears the data in both the long-term and **hot** databases, allowing you to repeat the workflows from a clean state if desired.
-
-## External BM25 Document Re-Ranker
-
-All query entry points (`query.py`, `example/query.py`, and the reinforcement-learning demo) call `common.ask(...)`, which now defaults to `external_ranker=True`. After OpenSearch returns results from **both** LT and HOT, the helper uses the lightweight [`bm25s`](https://github.com/xhluca/bm25s) library to re-rank the merged hit list locally. This keeps score math transparent, produces a single ordered context list for the LLM, and makes it obvious how each snippet earned its place. If you ever want to inspect raw OpenSearch ranking, pass `external_ranker=False` when calling `ask` or fork the script to expose a CLI flag.
-
-## Conclusion
-
-By following these workflows, you have deployed a dual-memory Document RAG Agent. We utilized Docker CLI commands to orchestrate a OpenSearch-based **long-term memory** and **hot memory** to build out this solution. The result is a retrieval-augmented generation pipeline that is **fast, transparent, and robust**: delivering sub-second query responses with full traceability of which facts were used and how they were processed through the system.
-
-For further exploration, consider pointing the ingestion pipeline at your data sources. You can also integrate a larger language model or an API-based model for the LLM component if needed.
-
-> **IMPORTANT:** This is modeled after a specific example, so your implementation might differ materially from the specifics here; however, the high-level concepts are the same.
-
-We hope this reference implementation provides a solid foundation for building **production-ready, enterprise-scale Document RAG** solutions. By combining OpenSearch databases with Kafka-based CDC and advanced storage like FlexCache, you can achieve AI systems that are **faster, clearer, safer, and compliant by design**. Happy building!


### PR DESCRIPTION
## Summary
- align the top-level README with the current community hybrid BM25 + vector RAG implementation
- rewrite community_version README with accurate setup, ingestion, query, and configuration details taken from the code

## Problem
Existing documentation described an older architecture and commands that no longer match the current Python implementation, making setup and usage confusing.

## Approach
Updated both READMEs to reflect the authoritative Python code paths: hybrid BM25/vector retrieval, NER service requirement, ingestion targets, query behavior, and configuration environment variables.

## Dependencies
- None

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f98d4068832f9d0e817748a71d35)