### PR TITLE
Enable Metal GPU offload defaults on Apple Silicon

### DIFF
--- a/community_version/tests/test_config.py
+++ b/community_version/tests/test_config.py
@@ -1,0 +1,35 @@
+"""Tests for configuration defaults."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from common.config import load_settings
+
+
+class TestConfigDefaults(unittest.TestCase):
+    """Validate platform-specific defaults for the LLaMA settings."""
+
+    def test_darwin_defaults_use_gpu_layers(self) -> None:
+        """Apple Silicon defaults to full GPU offload when unset."""
+
+        with patch("platform.system", return_value="Darwin"), patch(
+            "platform.machine", return_value="arm64"
+        ), patch.dict(os.environ, {}, clear=True):
+            settings = load_settings()
+        self.assertEqual(settings.llama_n_gpu_layers, -1)
+
+    def test_env_override_preserves_gpu_layers(self) -> None:
+        """Environment overrides take precedence over platform defaults."""
+
+        with patch("platform.system", return_value="Darwin"), patch(
+            "platform.machine", return_value="arm64"
+        ), patch.dict(os.environ, {"LLAMA_N_GPU_LAYERS": "12"}, clear=True):
+            settings = load_settings()
+        self.assertEqual(settings.llama_n_gpu_layers, 12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Local LLM serving on macOS Apple Silicon should prefer Metal/MPS GPU acceleration by default to improve performance.
- The existing LLaMA server could leave GPU offload disabled unless `LLAMA_N_GPU_LAYERS` was explicitly set, causing suboptimal runtimes on M1/M2 machines.
- Provide runtime visibility when Metal offload is active to help users understand resource usage.

### Description
- Default `LLAMA_N_GPU_LAYERS` to `-1` on Apple Silicon by adding `_default_llama_n_gpu_layers()` to `community_version/common/config.py` so the platform default offloads all layers when available.
- Add platform detection and selection helpers (`_is_apple_silicon`, `_resolve_gpu_layers`) in `community_version/llm_server.py` and pass the resolved `n_gpu_layers` into the `Llama` constructor while logging when Metal offload is chosen.
- Preserve explicit environment overrides by reading `LLAMA_N_GPU_LAYERS` with `_get_int`, so setting `LLAMA_N_GPU_LAYERS` takes precedence over the platform default.
- Dependency: `llama-cpp-python` is the existing library used to drive `llama.cpp` model loading and offload configuration (https://github.com/abetlen/llama-cpp-python) because it is a maintained Python wrapper for `llama.cpp` with the required constructor options.

### Testing
- Added unit tests at `community_version/tests/test_config.py` that assert the Darwin/arm64 default becomes `-1` and that an environment override is respected.
- No automated test suite was executed during this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0833fdd4832fb8a28e6fc58e5f8e)